### PR TITLE
Changes to work with latest stock mbed

### DIFF
--- a/hal/TARGET_NXP/TARGET_LPC15XX/DmaController.cpp
+++ b/hal/TARGET_NXP/TARGET_LPC15XX/DmaController.cpp
@@ -1,12 +1,12 @@
 #include "DmaController.h"
 
 uint32_t DmaController::dmaDescriptors_[18][4] __attribute__((aligned(512)));
-FunctionPointer DmaController::dmaCallbacks_[kNumDmaChannels];
+Callback<void()> DmaController::dmaCallbacks_[kNumDmaChannels];
 
 void DmaController::memToPeriphTransfer(volatile void* dst, void* src, size_t len,
     uint8_t channel, void (*callback)()) {
   if (callback) {
-    dmaCallbacks_[channel].attach(callback);
+    dmaCallbacks_[channel] = callback;
     memToPeriphTransfer(dst, src, len, channel, true);
   } else {
     memToPeriphTransfer(dst, src, len, channel, false);

--- a/hal/api/DmaController.h
+++ b/hal/api/DmaController.h
@@ -51,7 +51,7 @@ protected:
   static void irqHandler();
 
   static uint32_t dmaDescriptors_[kNumDmaChannels][4];
-  static FunctionPointer dmaCallbacks_[kNumDmaChannels];
+  static Callback<void()> dmaCallbacks_[kNumDmaChannels];
 };
 
 #endif

--- a/utils/can_buffer.h
+++ b/utils/can_buffer.h
@@ -86,7 +86,9 @@ public:
   /** Non-buffered passthrough write.
    */
   int write(CANMessage msg) {
-    return can.write(msg);
+    while (!can.write(msg)) {
+    }
+    return true;
   }
 
   /** CAN receive message IRQ handler

--- a/utils/can_buffer.h
+++ b/utils/can_buffer.h
@@ -22,16 +22,7 @@
  *  Typical usage:
  *    // 32 message buffer
  *    CANRXBuffer<32> canBuffer(can);
- *
- *    void handleCANMessage() {
- *        canBuffer.handleIrq();
- *    }
- *
- *    void setup() {
- *       // Do your other setup
- *       can.attach(handleCANMessage, CAN::RxIrq);
- *    }
- *
+
  *    void main() {
  *        while (1) {
  *            CANMessage msg;
@@ -45,233 +36,74 @@
 template <int RXSize>
 class CANRXBuffer {
 public:
-	/** Constructs a new, empty CAN message buffer
-	 *
-	 *  @param can CAN interface to read messages from
-	 *  @param handle message filter handle (0 for any message)
-	 */
-	CANRXBuffer(CAN& can, int handle=0) : can(can), handle(handle) {
+  /** Constructs a new, empty CAN message buffer
+   *
+   *  @param can CAN interface to read messages from
+   *  @param handle message filter handle (0 for any message)
+   */
+  CANRXBuffer(CAN& can, int handle=0) : can(can), handle(handle) {
+    can.attach(callback(this, &CANRXBuffer<RXSize>::handleIrq), CAN::RxIrq);
+  }
 
-	}
+  /** Check if the receive buffer is empty
+   *
+   *  @returns
+   *    true if empty
+   *    false if not empty
+   */
+  bool rxEmpty() const {
+    return rxBuffer.empty();
+  }
 
-	/** Check if the receive buffer is empty
-	 *
-	 *  @returns
-	 *    true if empty
-	 *    false if not empty
-	 */
-	bool rxEmpty() const {
-		return rxBuffer.empty();
-	}
+  /** Check if the receive buffer is full
+   *
+   *  @returns
+   *    true if full
+   *    false if not full
+   */
+  bool rxFull() const {
+    return rxBuffer.full();
+  }
 
-	/** Check if the receive buffer is full
-	 *
-	 *  @returns
-	 *    true if full
-	 *    false if not full
-	 */
-	bool rxFull() const {
-		return rxBuffer.full();
-	}
+  /** Read a CANMessage from the buffer.
+   *
+   *  @param msg A CANMessage to read to.
+   *
+   *  @returns
+   *    0 if no message arrived,
+   *    1 if message arrived
+   */
+  int read(CANMessage& msg) {
+    int messageValid = 0;
+    if (!rxEmpty()) {
+      msg = rxBuffer.read();
+      messageValid = 1;
+    }
 
-	/** Read a CANMessage from the buffer.
-	 *
-	 *  @param msg A CANMessage to read to.
-	 *
-	 *  @returns
-	 *    0 if no message arrived,
-	 *    1 if message arrived
-	 */
-	int read(CANMessage& msg) {
-		int messageValid = 0;
-		if (!rxEmpty()) {
-			msg = rxBuffer.read();
-			messageValid = 1;
-		}
+    return messageValid;
+  }
 
-		return messageValid;
-	}
+  /** Non-buffered passthrough write.
+   */
+  int write(CANMessage msg) {
+    return can.write(msg);
+  }
 
-	/** CAN receive message IRQ handler
-	 *  Reads any pending CAN messages into the RX buffer
-	 *  Stops when there are no more pending messages or the RX buffer is full
-	 */
-	void handleIrq() {
-		CANMessage msg;
-		while (can.read(msg, handle) && !rxFull()) {
-			rxBuffer.write(msg);
-		}
-	}
-
-private:
-	CircularBuffer<CANMessage, RXSize> rxBuffer;
-	CAN& can;
-	const int handle;
-};
-
-/** CAN Message circular buffer template class + IRQ handler
- *
- *  @param RXSize size of receive buffer in messages; must be a power of 2
- *  @param TXSize size of transmit buffer in messages; must be a power of 2
- *
- *  Typical usage:
- *    // 32 message RX buffer, 16 message TX buffer
- *    CANRXTXBuffer<32, 16> canBuffer(can);
- *
- *    void handleCANMessage() {
- *        canBuffer.handleIrq();
- *    }
- *
- *    void setup() {
- *       // Do your other setup
- *       can.attach(handleCANMessage, CAN::RxIrq);
- *       can.attach(handleCANMessage, CAN::TxIrq);
- *    }
- *
- *    void main() {
- *        while (1) {
- *            CANMessage msg;
- *            // Use CANRXTXBuffer::read instead of CAN::read
- *            if (canBuffer.read(msg)) {
- *                doStuff(msg);
- *            }
- *            // Use CANRXTXBuffer::write instead of CAN::write
- *            for (int i=0; i < 5; i++) {
- *                CANMessage someMessage = makeAMessage();
- *                canBuffer.write(someMessage);
- *            }
- *        }
- *    }
- */
-template <int RXSize, int TXSize>
-class CANRXTXBuffer {
-public:
-	/** Constructs a new, empty CAN message buffer
-	 *
-	 *  @param can CAN interface to read messages from
-	 *  @param handle message filter handle (0 for any message)
-	 */
-	CANRXTXBuffer(CAN& can, int handle=0) : can(can), handle(handle) {
-
-	}
-
-	/** Check if the receive buffer is empty
-	 *
-	 *  @returns
-	 *    true if empty
-	 *    false if not empty
-	 */
-	bool rxEmpty() const {
-		return rxBuffer.empty();
-	}
-
-	/** Check if the transmit buffer is empty
-	 *
-	 *  @returns
-	 *    true if empty
-	 *    false if not empty
-	 */
-	bool txEmpty() const {
-		return txBuffer.empty();
-	}
-
-	/** Check if the receive buffer is full
-	 *
-	 *  @returns
-	 *    true if full
-	 *    false if not full
-	 */
-	bool rxFull() const {
-		return rxBuffer.full();
-	}
-
-	/** Check if the transmit buffer is full
-	 *
-	 *  @returns
-	 *    true if full
-	 *    false if not full
-	 */
-	bool txFull() const {
-		return txBuffer.full();
-	}
-
-	/** Read a CANMessage from the buffer.
-	 *
-	 *  @param msg A CANMessage to read to.
-	 *
-	 *  @returns
-	 *    0 if no message arrived,
-	 *    1 if message arrived
-	 */
-	int read(CANMessage& msg) {
-		int messageValid = 0;
-		if (!rxEmpty()) {
-			msg = rxBuffer.read();
-			messageValid = 1;
-		}
-
-		return messageValid;
-	}
-
-	/** Write a CANMessage to the buffer.
-	 *
-	 *  @param msg A CANMessage to write.
-	 *
-	 *  @returns
-	 *    0 if no space in buffer,
-	 *    1 if message added to buffer
-	 */
-	int write(CANMessage msg) {
-		int messageQueued = 0;
-
-		if (txEmpty() && (can.txstatus() == CAN::Idle)) {
-			messageQueued = can.write(msg);
-		} else if (!txFull()) {
-			txBuffer.write(msg);
-			messageQueued = 1;
-		}
-
-		return messageQueued;
-	}
-
-	/**
-	 * Clear TX send buffer.
-	 */
-	void clearTX() {
-		txBuffer.clear();
-	}
-
-	/** CAN receive/transmit message IRQ handler
-	 *  Reads any pending CAN messages into the RX buffer
-	 *  Stops when there are no more pending messages or the RX buffer is full
-	 *  If the CAN interface is idle, transmits a message from the TX buffer
-	 */
-	void handleRxIrq() {
-		CANMessage msg;
-		while (can.read(msg, handle) && !rxFull()) {
-			rxBuffer.write(msg);
-		}
-	}
-	void handleTxIrq() {
-		while (!txEmpty()) {
-			if (can.write(txBuffer.peek()) != 0) {
-				txBuffer.discard();
-			} else {
-				//break;
-			}
-		}
-	}
-	void handleIrq() {
-		handleRxIrq();
-		handleTxIrq();
-	}
+  /** CAN receive message IRQ handler
+   *  Reads any pending CAN messages into the RX buffer
+   *  Stops when there are no more pending messages or the RX buffer is full
+   */
+  void handleIrq() {
+    CANMessage msg;
+    while (can.read(msg, handle) && !rxFull()) {
+      rxBuffer.write(msg);
+    }
+  }
 
 private:
-	CircularBuffer<CANMessage, RXSize> rxBuffer;
-	CircularBuffer<CANMessage, TXSize> txBuffer;
-	CAN& can;
-	const int handle;
+  calsol::util::CircularBuffer<CANMessage, RXSize> rxBuffer;
+  CAN& can;
+  const int handle;
 };
-
 
 #endif // __ZEPHYR_COMMON_CAN_BUFFER_H__

--- a/utils/can_buffer_timestamp.h
+++ b/utils/can_buffer_timestamp.h
@@ -56,7 +56,6 @@ public:
    */
   CANTimestampedRxBuffer(CAN& can, LongTimer& t,int handle=0): can(can), handle(handle), timer(t) {
     can.attach(callback(this, &CANTimestampedRxBuffer<RXSize>::handleIrq), CAN::RxIrq);
-    can.attach(callback(this, &CANTimestampedRxBuffer<RXSize>::handleIrq), CAN::TxIrq);
     can.attach(callback(this, &CANTimestampedRxBuffer<RXSize>::handle_EWIRQ), CAN::EwIrq);
     can.attach(callback(this, &CANTimestampedRxBuffer<RXSize>::handle_DOIRQ), CAN::DoIrq);
     can.attach(callback(this, &CANTimestampedRxBuffer<RXSize>::handle_EPIRQ), CAN::EpIrq);

--- a/utils/circular_buffer.h
+++ b/utils/circular_buffer.h
@@ -8,102 +8,107 @@
 #ifndef ZEPHYR_COMMON_API_CIRCULAR_BUFFER_H_
 #define ZEPHYR_COMMON_API_CIRCULAR_BUFFER_H_
 
+namespace calsol {
+namespace util {
+
 constexpr bool isPowerOfTwo(int x) {
-	return x > 0 && ((x & (x-1)) == 0);
+  return x > 0 && ((x & (x-1)) == 0);
 }
 /*
  * Circular buffer template class
  */
 template <class T, int N>
 class CircularBuffer {
-	static_assert(isPowerOfTwo(N), "Buffer size must be a power of 2 for efficiency");
+  static_assert(isPowerOfTwo(N), "Buffer size must be a power of 2 for efficiency");
 
 public:
-	/** Constructs a new, empty circular buffer capable of storing up to
-	 *  N - 1 elements.
-	 */
-	CircularBuffer() : start(0), end(0) {};
+  /** Constructs a new, empty circular buffer capable of storing up to
+   *  N - 1 elements.
+   */
+  CircularBuffer() : start(0), end(0) {};
 
-	/** Check if the buffer is full
-	 *
-	 *  @returns
-	 *    true if full
-	 *    false if not full
-	 */
-	bool full() const {
-		return (this->end + 1) % N == this->start;
-	}
+  /** Check if the buffer is full
+   *
+   *  @returns
+   *    true if full
+   *    false if not full
+   */
+  bool full() const {
+    return (this->end + 1) % N == this->start;
+  }
 
-	/** Check if the buffer is empty
-	 *
-	 *  @returns
-	 *    true if empty
-	 *    false if not empty
-	 */
-	bool empty() const {
-		return this->start == this->end;
-	}
+  /** Check if the buffer is empty
+   *
+   *  @returns
+   *    true if empty
+   *    false if not empty
+   */
+  bool empty() const {
+    return this->start == this->end;
+  }
 
-	/** Adds an element of type T to the end of the buffer
-	 *
-	 *  Note: the caller is responsible for checking that
-	 *        the buffer is not already full
-	 *
-	 *  @param s element to append
-	 */
-	void write(T s) {
-		this->buffer[this->end] = s;
-		this->end = (this->end + 1) % N;
-	}
+  /** Adds an element of type T to the end of the buffer
+   *
+   *  Note: the caller is responsible for checking that
+   *        the buffer is not already full
+   *
+   *  @param s element to append
+   */
+  void write(T s) {
+    this->buffer[this->end] = s;
+    this->end = (this->end + 1) % N;
+  }
 
-	/** Pops the element at the front of the buffer
-	 *
-	 *  Note: the caller is responsible for checking that
-	 *        the buffer is not empty
-	 *
-	 *  @returns
-	 *    element at front of the buffer
-	 */
-	T read() {
-		T s = this->buffer[this->start];
-		this->start = (this->start + 1) % N;
-		return s;
-	}
+  /** Pops the element at the front of the buffer
+   *
+   *  Note: the caller is responsible for checking that
+   *        the buffer is not empty
+   *
+   *  @returns
+   *    element at front of the buffer
+   */
+  T read() {
+    T s = this->buffer[this->start];
+    this->start = (this->start + 1) % N;
+    return s;
+  }
 
-	/** Reads the element at the front of the buffer without removing it
-	 *
-	 *  Note: the caller is responsible for checking that
-	 *        the buffer is not empty
-	 *
-	 *  @returns
-	 *    element at front of the buffer
-	 */
-	const T& peek() {
-		return this->buffer[this->start];
-	}
+  /** Reads the element at the front of the buffer without removing it
+   *
+   *  Note: the caller is responsible for checking that
+   *        the buffer is not empty
+   *
+   *  @returns
+   *    element at front of the buffer
+   */
+  const T& peek() {
+    return this->buffer[this->start];
+  }
 
-	/** Removes the element at the front of the buffer without reading it
-	 *
-	 *  Note: the caller is responsible for checking that
-	 *        the buffer is not empty
-	 *
-	 */
-	void discard() {
-		this->start = (this->start + 1) % N;
-	}
+  /** Removes the element at the front of the buffer without reading it
+   *
+   *  Note: the caller is responsible for checking that
+   *        the buffer is not empty
+   *
+   */
+  void discard() {
+    this->start = (this->start + 1) % N;
+  }
 
-	/** Empties the buffer
-	 *
-	 *  Note: does not actually destroy any objects
-	 *
-	 */
-	void clear() {
-		this->start = this->end = 0;
-	}
+  /** Empties the buffer
+   *
+   *  Note: does not actually destroy any objects
+   *
+   */
+  void clear() {
+    this->start = this->end = 0;
+  }
 
 private:
-	T buffer[N];
-	volatile int start, end;
+  T buffer[N];
+  volatile int start, end;
 };
+
+}}
 
 #endif /* ZEPHYR_COMMON_API_CIRCULAR_BUFFER_H_ */

--- a/utils/debug.cpp
+++ b/utils/debug.cpp
@@ -3,10 +3,15 @@
 
 extern DmaSerial<1024> swdConsole;
 
-namespace debug {
+namespace calsol {
+namespace util {
+
+namespace debugConsole {
 char buffer[128];
 
 void puts(const char* string) {
   swdConsole.puts(string);
 }
 }
+
+}}

--- a/utils/debug.h
+++ b/utils/debug.h
@@ -9,10 +9,15 @@
   #define DEBUG_MODULE __FILE__
 #endif
 
-namespace debug {
+namespace calsol {
+namespace util {
+
+namespace debugConsole {
   extern char buffer[];
   void puts(const char* string);
 }
+
+}}
 
 #ifdef DEBUG_ENABLED
 
@@ -20,20 +25,20 @@ namespace debug {
 #define TOSTRING(x) STRINGIFY(x)
 
 #define debugPrint(f, ...)  \
-  sprintf(debug::buffer, f, ## __VA_ARGS__);  \
-  debug::puts(debug::buffer);  \
+  sprintf(calsol::util::debugConsole::buffer, f, ## __VA_ARGS__);  \
+  calsol::util::debugConsole::puts(calsol::util::debugConsole::buffer);  \
 
 #define debugInfo(f, ...)  \
-  debug::puts("\033[36mInfo)\033[0m " DEBUG_MODULE " " TOSTRING(__LINE__) ": ");  \
-  sprintf(debug::buffer, f, ## __VA_ARGS__);  \
-  debug::puts(debug::buffer);  \
-  debug::puts("\r\n");
+  calsol::util::debugConsole::puts("\033[36mInfo)\033[0m " DEBUG_MODULE " " TOSTRING(__LINE__) ": ");  \
+  sprintf(calsol::util::debugConsole::buffer, f, ## __VA_ARGS__);  \
+  calsol::util::debugConsole::puts(calsol::util::debugConsole::buffer);  \
+  calsol::util::debugConsole::puts("\r\n");
 
 #define debugWarn(f, ...)  \
-  debug::puts("\033[33mWarn)\033[0m " DEBUG_MODULE " " TOSTRING(__LINE__) ": ");  \
-  sprintf(debug::buffer, f, ## __VA_ARGS__);  \
-  debug::puts(debug::buffer);  \
-  debug::puts("\r\n");
+  calsol::util::debugConsole::puts("\033[33mWarn)\033[0m " DEBUG_MODULE " " TOSTRING(__LINE__) ": ");  \
+  sprintf(calsol::util::debugConsole::buffer, f, ## __VA_ARGS__);  \
+  calsol::util::debugConsole::puts(calsol::util::debugConsole::buffer);  \
+  calsol::util::debugConsole::puts("\r\n");
 
 #else
 


### PR DESCRIPTION
- namespace qualify debug and circular buffer
- remove CAN RXTX buffer since that depends on a custom CAN API which isn't in upstream, this can be reimplemented by tracking whether the CAN module is transmitting on the buffer side
- attach interrupts CAN buffers on instantiation, so there's no need to add boilerplate in application code
- add passthrough writes to CAN buffers
