### PR TITLE
Add lpc1549 openocd target, with compatibility for recent openocd versions

### DIFF
--- a/openocd_targets/lpc1549.cfg
+++ b/openocd_targets/lpc1549.cfg
@@ -1,0 +1,66 @@
+# NXP LPC1549 (based on lpc1xxx.cfg)
+set _CHIPNAME lpc1549
+set _WORKAREASIZE 0x9000
+set _CHIPSERIES lpc1500
+set _BANKSIZE 0x40000
+
+source [find target/swj-dp.tcl]
+
+if { [info exists CCLK] } {
+	# Allow user override
+	set _CCLK $CCLK
+} else {
+	set _CCLK 12000
+}
+
+if { [info exists CPUTAPID] } {
+	# Allow user override
+	set _CPUTAPID $CPUTAPID
+} else {
+	if { [using_jtag] } {
+		set _CPUTAPID 0x4ba00477
+	} {
+		set _CPUTAPID 0x2ba01477
+	}
+}
+
+# Parse the version string to determine which target creation command to invoke
+# since they have mutually exclusive APIs
+regexp (\\d+)\\.(\\d+)\\.(\\d+)(?:\\+dev)?\\-(\\d+) [version] DUMMY VER_1 VER_2 VER_3 VER_BUILD
+
+if { ($VER_1 > 0 || $VER_2 > 10 || $VER_3 > 0 || $VER_BUILD > 254) } {
+  swj_newdap $_CHIPNAME cpu -irlen 4 -expected-id $_CPUTAPID
+  dap create $_CHIPNAME.dap -chain-position $_CHIPNAME.cpu
+
+  set _TARGETNAME $_CHIPNAME.cpu
+  target create $_TARGETNAME cortex_m -dap $_CHIPNAME.dap
+} else {
+  swj_newdap $_CHIPNAME cpu -irlen 4 -expected-id $_CPUTAPID
+
+  set _TARGETNAME $_CHIPNAME.cpu
+  target create $_TARGETNAME cortex_m -chain-position $_TARGETNAME
+}
+
+$_TARGETNAME configure -work-area-phys 0x02000000 -work-area-size $_WORKAREASIZE
+
+set _FLASHNAME $_CHIPNAME.flash
+flash bank $_FLASHNAME lpc2000 0x0 $_BANKSIZE 0 0 $_TARGETNAME \
+  lpc1500 $_CCLK calc_checksum
+
+$_TARGETNAME configure -event reset-init {
+	mww 0x40074000 0x02
+}
+
+adapter_khz 4000
+
+# delays on reset lines
+adapter_nsrst_delay 200
+if {[using_jtag]} {
+ jtag_ntrst_delay 200
+}
+
+# LPC13xx/LPC15xx/LPC17xx (Cortex M3 core) support SYSRESETREQ
+if {![using_hla]} {
+    # if srst is not fitted use SYSRESETREQ to perform a soft reset
+    cortex_m reset_config sysresetreq
+}


### PR DESCRIPTION
Uses a regex to parse the version number and select the appropriate command to run. There seems to have been an config-API breaking change in a recent version of OpenOCD - while they updated their included target scripts, lpc1549 still isn't among those. Note that we can't just import the lpc1xxx.cfg script, since it does a strict check for chip series, and the memory/flash configs don't match what w ehave here.

The version threshold isn't strict, but it works on the latest installer build from GNU MCU Eclipse (which is what we recommend, I think) and the latest binary version on their site. I don't expect anyone to have using an in-between version.

Requires updates to the braintrain and Tachyon-FW repos to point to this shared file. In Tachyon-FW I'll leave a shim lpc1549_openocd.cfg file that loads this file, for people with IDEs pointing to that file.
