### PR TITLE
Button gesture detector + Microchip ADC and DAC drivers

### DIFF
--- a/drivers/Mcp3201.cpp
+++ b/drivers/Mcp3201.cpp
@@ -1,0 +1,24 @@
+#include "Mcp3201.h"
+
+
+Mcp3201::Mcp3201(SPI& spi, DigitalOut& cs) : spi_(spi), cs_(cs) {
+  cs_ = 1;
+}
+
+// reads ADC as a 12-bit value
+// frequency must be set externally, which also determines the sample rate
+uint16_t Mcp3201::read_raw_u12() {
+  spi_.format(8, 0);
+  cs_ = 0;
+  // first two clocks are for sampling, then one null bit, then data
+  // and last bit (in a 16 bit transfer) is unused
+  uint8_t byte0 = spi_.write(0);
+  uint8_t byte1 = spi_.write(0);
+  cs_ = 1;
+  return (((uint16_t)(byte0 & 0x1f) << 8) | byte1) >> 1;
+}  
+
+// reads ADC scaled up to a 16-bit value
+uint16_t Mcp3201::read_u16() {
+  return read_raw_u12() * 16;
+}

--- a/drivers/Mcp3201.cpp
+++ b/drivers/Mcp3201.cpp
@@ -20,5 +20,5 @@ uint16_t Mcp3201::read_raw_u12() {
 
 // reads ADC scaled up to a 16-bit value
 uint16_t Mcp3201::read_u16() {
-  return read_raw_u12() * 16;
+  return (uint32_t)read_raw_u12() * 65535 / 4095;
 }

--- a/drivers/Mcp3201.h
+++ b/drivers/Mcp3201.h
@@ -1,0 +1,23 @@
+#include <mbed.h>
+
+#ifndef __MCP3201_H__
+#define __MCP3201_H__
+
+
+// MCP3201 12-bit SPI ADC
+class Mcp3201 {
+public:
+  Mcp3201(SPI& spi, DigitalOut& cs);
+
+  // reads ADC as a 12-bit value
+  // frequency must be set externally, which also determines the sample rate
+  uint16_t read_raw_u12();
+  // reads ADC scaled up to a 16-bit value
+  uint16_t read_u16();
+
+protected:
+  SPI& spi_;
+  DigitalOut& cs_;
+};
+
+#endif  // __MCP3201_H__

--- a/drivers/Mcp4921.cpp
+++ b/drivers/Mcp4921.cpp
@@ -15,5 +15,5 @@ void Mcp4921::write_raw_u12(uint16_t value) {
 }  
 
 void Mcp4921::write_u16(uint16_t value) {
-  write_raw_u12(value / 16);
+  write_raw_u12((uint32_t)value * 4095 / 65535);
 }

--- a/drivers/Mcp4921.cpp
+++ b/drivers/Mcp4921.cpp
@@ -1,0 +1,19 @@
+#include "Mcp4921.h"
+
+  
+Mcp4921::Mcp4921(SPI& spi, DigitalOut& cs) : spi_(spi), cs_(cs) {
+  cs_ = 1;
+}
+
+void Mcp4921::write_raw_u12(uint16_t value) {
+  spi_.format(8, 0);
+  cs_ = 0;
+  // first 4 bits: write DACA, unbuffered mode, 1x gain, enable
+  spi_.write(0x30 | ((value >> 8) & 0x0f));
+  spi_.write(value & 0xff);
+  cs_ = 1;
+}  
+
+void Mcp4921::write_u16(uint16_t value) {
+  write_raw_u12(value / 16);
+}

--- a/drivers/Mcp4921.h
+++ b/drivers/Mcp4921.h
@@ -1,0 +1,23 @@
+#include <mbed.h>
+
+#ifndef __MCP4921_H__
+#define __MCP4921_H__
+
+
+// MCP4921 12-bit SPI DAC
+class Mcp4921 {
+public:
+  Mcp4921(SPI& spi, DigitalOut& cs);
+
+  // writes a 12-bit value to the DAC
+  // LDAC must be set externally
+  void write_raw_u12(uint16_t value);
+  // writes DAC scaled down from a 16-bit value
+  void write_u16(uint16_t value);
+
+protected:
+  SPI& spi_;
+  DigitalOut& cs_;
+};
+
+#endif  // __MCP4921_H__

--- a/hal/TARGET_NXP/TARGET_LPC15XX/AnalogPeripherals.cpp
+++ b/hal/TARGET_NXP/TARGET_LPC15XX/AnalogPeripherals.cpp
@@ -1,3 +1,5 @@
+#ifdef TARGET_LPC15XX
+
 #include "AnalogPeripherals.h"
 
 #include "analogin_api.h"
@@ -83,3 +85,5 @@ unsigned short TempSensor::read_u16() {
   LPC_ADC0->INSEL = ADCn_INSEL_ADC;
   return readOut;
 }
+
+#endif

--- a/hal/TARGET_NXP/TARGET_LPC15XX/DmaController.cpp
+++ b/hal/TARGET_NXP/TARGET_LPC15XX/DmaController.cpp
@@ -1,3 +1,5 @@
+#ifdef TARGET_LPC15XX
+
 #include "DmaController.h"
 
 uint32_t DmaController::dmaDescriptors_[18][4] __attribute__((aligned(512)));
@@ -63,3 +65,5 @@ void DmaController::irqHandler() {
     }
   }
 }
+
+#endif

--- a/hal/TARGET_NXP/TARGET_LPC15XX/DmaSerial.cpp
+++ b/hal/TARGET_NXP/TARGET_LPC15XX/DmaSerial.cpp
@@ -1,3 +1,5 @@
+#ifdef TARGET_LPC15XX
+
 #include "DmaSerial.h"
 
 DmaSerialBase::DmaSerialBase(PinName tx, PinName rx, int baud, uint8_t* bufferBegin, uint8_t* bufferEnd) :
@@ -125,3 +127,4 @@ void DmaSerialBase::irqTransferDone() {
   }
 }
 
+#endif

--- a/hal/TARGET_NXP/TARGET_LPC15XX/EEPROM.cpp
+++ b/hal/TARGET_NXP/TARGET_LPC15XX/EEPROM.cpp
@@ -1,3 +1,5 @@
+#ifdef TARGET_LPC15XX
+
 #include <EEPROM.h>
 
 void EEPROM::init() {
@@ -30,3 +32,5 @@ void EEPROM::read(uint32_t address, uint8_t *data, uint32_t bytes) {
 
     iap_entry(command_param, status_result);
 }
+
+#endif

--- a/hal/api/AnalogPeripherals.h
+++ b/hal/api/AnalogPeripherals.h
@@ -1,3 +1,4 @@
+#ifdef TARGET_LPC15XX
 #ifndef _ANALOGPERIPHERALS_H_
 #define _ANALOGPERIPHERALS_H_
 
@@ -28,4 +29,5 @@ protected:
     analogin_t _adc;
 };
 
+#endif
 #endif

--- a/hal/api/DmaController.h
+++ b/hal/api/DmaController.h
@@ -1,3 +1,4 @@
+#ifdef TARGET_LPC15XX
 #ifndef _DMA_CONTROLLER_H_
 #define _DMA_CONTROLLER_H_
 
@@ -54,4 +55,5 @@ protected:
   static Callback<void()> dmaCallbacks_[kNumDmaChannels];
 };
 
+#endif
 #endif

--- a/hal/api/DmaSerial.h
+++ b/hal/api/DmaSerial.h
@@ -1,3 +1,4 @@
+#ifdef TARGET_LPC15XX
 #ifndef _DMA_SERIAL_H_
 #define _DMA_SERIAL_H_
 
@@ -48,4 +49,5 @@ protected:
   uint8_t buffer_[N];
 };
 
+#endif
 #endif

--- a/hal/api/EEPROM.h
+++ b/hal/api/EEPROM.h
@@ -1,3 +1,4 @@
+#ifdef TARGET_LPC15XX
 #ifndef __EEPROM_H_
 #define __EEPROM_H_
 
@@ -19,4 +20,5 @@ namespace EEPROM {
 
 }
 
+#endif
 #endif

--- a/hal/api/WDT.h
+++ b/hal/api/WDT.h
@@ -3,6 +3,7 @@
  *
  * Watchdog timer implementation
  */
+#ifdef TARGET_LPC15XX
 #ifndef __WDT_H__
 #define __WDT_H__
 
@@ -39,3 +40,4 @@ class WDT {
 };
 
 #endif /* __WDT_H__*/
+#endif

--- a/utils/ButtonGesture.cpp
+++ b/utils/ButtonGesture.cpp
@@ -1,0 +1,56 @@
+#include "ButtonGesture.h"
+
+
+ButtonGesture::ButtonGesture(DigitalIn& din, int clickTimeMs, int holdRepeatMs, int debounceTimeMs) :
+    din_(din), clickTimeMs_(clickTimeMs), holdRepeatMs_(holdRepeatMs), debounceTimeMs_(debounceTimeMs) {
+  debounceTimer_.start();
+  pressTimer_.start();
+}
+
+ButtonGesture::Gesture ButtonGesture::update() {
+  bool buttonState = din_;
+  bool newDebounceState = debouncedState_;
+  if (buttonState != debouncedState_) {
+    if (debounceTimer_.read_ms() > debounceTimeMs_) {
+      newDebounceState = buttonState;
+    }
+  } else {
+    debounceTimer_.reset();
+  }
+
+  Gesture result;
+  if (newDebounceState != debouncedState_) {  // edge
+    if (!newDebounceState) {  // down edge
+      pressTimer_.reset();
+      result = Gesture::kClickPress;
+    } else {  // up edge
+      if (isLongPress_) {
+        result = Gesture::kHoldRelease;
+      } else {
+        result = Gesture::kClickRelease;
+      }
+      isLongPress_ = false;
+    }
+  } else {  // holding
+    if (!newDebounceState) {  // held down
+      if (!isLongPress_ && pressTimer_.read_ms() > clickTimeMs_) {  // new long press
+        isLongPress_ = true;
+        pressTimer_.reset();
+        result = Gesture::kHoldTransition;
+      } else if (isLongPress_) {  // holding previous long press
+        if (pressTimer_.read_ms() > holdRepeatMs_) {
+          pressTimer_.reset();
+          result = Gesture::kHoldRepeat;
+        } else {
+          result = Gesture::kHold;
+        }
+      } else {  // not long press
+        result = Gesture::kDown;
+      }
+    } else {  // released up
+      result = Gesture::kUp;
+    }
+  }
+  debouncedState_ = newDebounceState;
+  return result;
+}

--- a/utils/ButtonGesture.h
+++ b/utils/ButtonGesture.h
@@ -1,0 +1,39 @@
+#include <mbed.h>
+
+#ifndef __BUTTON_GESTURE_H__
+#define __BUTTON_GESTURE_H__
+
+/**
+ * Button gesture detector (click / click-and-hold / long press) with debouncing.
+ */
+class ButtonGesture {
+public:
+  enum Gesture {
+    kUp,  // repeatedly emitted when not pressed (up)
+    kClickPress,  // emitted on press edge (up to down)
+    kDown,  // repeatedly emitted when pressed, but not held long enough to be a long press
+    kClickRelease,  // emitted on release edge (down to up), when not held long enough to be a long press
+    kHoldTransition,  // emitted once when held long enough to be a long press
+    kHold,  // repeatedly emitted when held long enough to be a long press
+    kHoldRepeat,  // emitted periodically (every holdRepeatMs) when held long enough to e a long press
+    kHoldRelease,  // emitted on release edge (down to up), when held long enough to be a long press
+  };
+
+  ButtonGesture(DigitalIn& din, int clickTimeMs=700, int holdRepeatMs=100, int debounceTimeMs=50);
+  Gesture update();
+
+protected:
+  DigitalIn& din_;
+  
+  int clickTimeMs_;  // duration boundary between click and click-and-hold
+  int holdRepeatMs_;  // duration between generating hold repeat events
+  int debounceTimeMs_;  // duration to debounce edge - must be stable for this long to register change
+
+  Timer debounceTimer_;
+  Timer pressTimer_;
+
+  bool debouncedState_ = true;  // inverted logic, true is up
+  bool isLongPress_ = false;
+};
+
+#endif  // __BUTTON_GESTURE_H__

--- a/utils/debug.cpp
+++ b/utils/debug.cpp
@@ -1,3 +1,5 @@
+#ifndef NONDEFAULT_DEBUG_CONSOLE
+
 #include "mbed.h"
 #include "DmaSerial.h"
 
@@ -15,3 +17,5 @@ void puts(const char* string) {
 }
 
 }}
+
+#endif


### PR DESCRIPTION
Some utility code broken out of the SMU firmware:
- MCP4921 DAC driver
- MCP3201 ADC driver
- Button gesture detector, that wraps around a DigitalIn and provides a polling-based status that detects:
  - Button click press (down), release (up), long press (hold - default >700ms) transition, and long press release
  - Timed repeats during a long press (default every 100ms)
  - Status events up, down, holding
- `ifdef` gate the LPC15xx-specific drivers, to allow this to build on other targets (like the nRF series BLE micros)